### PR TITLE
feat: add riscv64 grub-efi support

### DIFF
--- a/src/modules/bootloader/main.py
+++ b/src/modules/bootloader/main.py
@@ -578,6 +578,8 @@ def get_grub_efi_parameters():
         return "arm64-efi", "grubaa64.efi", "bootaa64.efi"
     elif efi_bitness == "64" and cpu_type == "loongarch64":
         return "loongarch64-efi", "grubloongarch64.efi", "bootloongarch64.efi"
+    elif efi_bitness == "64" and cpu_type == "riscv64":
+        return "riscv64-efi", "grubriscv64.efi", "bootriscv64.efi"
     elif efi_bitness == "64":
         # If it's not ARM, must by AMD64
         return "x86_64-efi", "grubx64.efi", "bootx64.efi"


### PR DESCRIPTION
Backport from: https://codeberg.org/Calamares/calamares/pulls/2457

Add riscv64 grub-efi support to install system on riscv64 successfully
Test Platform:
Host: GXDE OS 25.2.1 (Debian13), amd64
Qemu 10.0.3 + qemu-efi-riscv64
Virtual Machine:
GXDE OS 25.2.1 (Debian13), riscv64
<img width="1600" height="828" alt="image" src="https://github.com/user-attachments/assets/b6c01642-50d1-4211-a549-bc581de65b21" />
